### PR TITLE
Remove README TODO section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,6 @@ Lightweight, client-side questionnaire that maps playful questions to trait dime
 ## Highest-Impact Next Step
 - Add shareable results via URL parameters so users can revisit and share outcomes.
 
-## Checks
-- Status: failing (GitHub Actions: Deploy GitHub Pages).
-- Issue: https://github.com/signalreason/whattodo/issues/3
-- TODO: Investigate Pages deployment queue timeouts.
-
 ## Run locally
 
 Option 1 (quick):


### PR DESCRIPTION
Agent-Status: ready

## Summary
- Remove README TODO items now tracked as GitHub issues.
- Drop the README section that previously held TODOs.

## Scope
- README cleanup only.

## Dependencies
- None.

## Acceptance Criteria
- [ ] README TODO lines are removed.
- [ ] The section containing README TODOs is removed.

## Test Plan
- [ ] Not applicable (docs-only change).